### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 LayerZero OFT MCP is a TypeScript/Node.js Model Context Protocol (MCP) server for creating, deploying, and bridging [Omnichain Fungible Tokens (OFTs)](https://docs.layerzero.network/v2/concepts/applications/oft-standard#omnichain-tokens) across multiple blockchains. Interactions are primarily managed via `ethers.js`, leveraging LayerZero contracts and protocols for cross-chain communication.
 
+<a href="https://glama.ai/mcp/servers/@thomasfevre/layerzero_mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@thomasfevre/layerzero_mcp/badge" alt="LayerZero OFT Server MCP server" />
+</a>
+
 This MCP abstracts the complexity of omnichain token creation and cross-chain interactions by providing a structured, context-aware layer for initiating, managing, and bridging OFTs. It is designed for easy integration with LLM agents, bots, or applications that require secure and reliable access to decentralized cross-chain functionality.
 
 **Deterministic Cross-Chain Contract Addressing**  


### PR DESCRIPTION
This PR adds a badge for the [LayerZero OFT MCP Server](https://glama.ai/mcp/servers/@thomasfevre/layerzero_mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@thomasfevre/layerzero_mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@thomasfevre/layerzero_mcp/badge" alt="LayerZero OFT Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.